### PR TITLE
new Buffer >> Buffer.alloc() = node security update

### DIFF
--- a/share-clipboard.js
+++ b/share-clipboard.js
@@ -24,7 +24,7 @@ function checkAndPushText() {
   }
   // create message
   var messageLength = Buffer.byteLength(clipboardText, 'utf8') + 8;
-  var messageData = new Buffer(messageLength);
+  var messageData = Buffer.alloc(messageLength);
   // message length
   messageData.writeInt32BE(messageLength, 0);
   // clipboard type


### PR DESCRIPTION
node security update

(node:15707) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.